### PR TITLE
feat: compatible with Toggl API v9

### DIFF
--- a/libtoggl.py
+++ b/libtoggl.py
@@ -1,8 +1,6 @@
 import re
 from datetime import datetime, timedelta, timezone
 
-from decouple import config
-from requests.models import PreparedRequest
 from toggl.TogglPy import Toggl, Endpoints
 from urllib.parse import urlencode
 from datetime import datetime, timedelta, timezone
@@ -38,11 +36,10 @@ class TogglTimesheets:
         if end_date:
             params["end_date"] = end_date
 
-        # Make request and return
-        return self.toggl.request(Endpoints.TIME_ENTRIES, parameters=params)
+        return self.toggl.request("https://api.track.toggl.com/api/v9/me/time_entries", parameters=params)
 
     def _get_raw_timelogs_last_n_days(self, n_days):
-        last_n_days = datetime.utcnow() - timedelta(days=n_days)
+        last_n_days = datetime.now(timezone.UTC) - timedelta(days=n_days)
         last_n_days_str = last_n_days.replace(
             microsecond=0, tzinfo=timezone.utc
         ).isoformat()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,6 @@
-certifi==2020.6.20
-chardet==3.0.4
-click==7.1.2
-decorator==4.4.0
-idna==2.8
-python-dateutil==2.8.0
+click==8.1.7
 python-decouple==3.1
-requests==2.25.1
-six==1.15.0
-TogglPy==0.1.2
-traitlets==4.3.2
-typed-ast==1.4.1
-urllib3==1.26.6
-black==21.6b0
+requests==2.32.2
+# TogglPy==0.1.2 doesn't support the new API. This fork from pixolus (plus minor tweaks from demid) does:
+git+https://github.com/0x29a/TogglPy.git@4068ad29aae4b120b0e49a27ce1e7a012dc12e01
+black==24.4.2

--- a/sync_timelogs.py
+++ b/sync_timelogs.py
@@ -3,10 +3,9 @@ import argparse
 import sys
 
 import click
-from datetime import datetime, timedelta, timezone
-from dateutil import parser
+from datetime import datetime
 from decouple import config
-from libtoggl import TogglTimesheets, Timelog
+from libtoggl import TogglTimesheets
 from libtempo import JiraTempoTimelogsDriver
 
 


### PR DESCRIPTION
This removes a whole bunch of unused dependencies, upgrades to the latest version of other dependencies, and fixes the script so that it uses the Toggl "v9" API, as the "v8" API is no longer working.